### PR TITLE
fix: site.css/contact.js 캐시 무효화용 버전 파라미터 추가

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -13,9 +13,9 @@
   <link rel="alternate" hreflang="es" href="https://gigaroute.ai/index-es.html">
   <link rel="alternate" hreflang="ja" href="https://gigaroute.ai/index-ja.html">
   <link rel="alternate" hreflang="x-default" href="https://gigaroute.ai/">
-  <link rel="stylesheet" href="site.css">
+  <link rel="stylesheet" href="site.css?v=20260904-3">
   <style>.consulting-panel:after{display:none!important}.consulting-panel+.consulting-panel{margin-top:28px}.actions .linux-download{pointer-events:none;cursor:not-allowed;opacity:.42;filter:grayscale(1)}</style>
-  <script src="contact.js" defer></script>
+  <script src="contact.js?v=20260904-3" defer></script>
   <script>window.addEventListener('DOMContentLoaded',()=>{const b=document.querySelector('.actions .linux-download');if(b){b.removeAttribute('href');b.removeAttribute('target');b.setAttribute('aria-disabled','true');b.setAttribute('tabindex','-1')}})</script>
 </head>
 <body>

--- a/index-es.html
+++ b/index-es.html
@@ -13,9 +13,9 @@
   <link rel="alternate" hreflang="es" href="https://gigaroute.ai/index-es.html">
   <link rel="alternate" hreflang="ja" href="https://gigaroute.ai/index-ja.html">
   <link rel="alternate" hreflang="x-default" href="https://gigaroute.ai/">
-  <link rel="stylesheet" href="site.css">
+  <link rel="stylesheet" href="site.css?v=20260904-3">
   <style>.consulting-panel:after{display:none!important}.consulting-panel+.consulting-panel{margin-top:28px}.actions .linux-download{pointer-events:none;cursor:not-allowed;opacity:.42;filter:grayscale(1)}</style>
-  <script src="contact.js" defer></script>
+  <script src="contact.js?v=20260904-3" defer></script>
   <script>window.addEventListener('DOMContentLoaded',()=>{const b=document.querySelector('.actions .linux-download');if(b){b.removeAttribute('href');b.removeAttribute('target');b.setAttribute('aria-disabled','true');b.setAttribute('tabindex','-1')}})</script>
 </head>
 <body>

--- a/index-ja.html
+++ b/index-ja.html
@@ -13,9 +13,9 @@
   <link rel="alternate" hreflang="es" href="https://gigaroute.ai/index-es.html">
   <link rel="alternate" hreflang="ja" href="https://gigaroute.ai/index-ja.html">
   <link rel="alternate" hreflang="x-default" href="https://gigaroute.ai/">
-  <link rel="stylesheet" href="site.css">
+  <link rel="stylesheet" href="site.css?v=20260904-3">
   <style>.consulting-panel:after{display:none!important}.consulting-panel+.consulting-panel{margin-top:28px}.actions .linux-download{pointer-events:none;cursor:not-allowed;opacity:.42;filter:grayscale(1)}</style>
-  <script src="contact.js" defer></script>
+  <script src="contact.js?v=20260904-3" defer></script>
   <script>window.addEventListener('DOMContentLoaded',()=>{const b=document.querySelector('.actions .linux-download');if(b){b.removeAttribute('href');b.removeAttribute('target');b.setAttribute('aria-disabled','true');b.setAttribute('tabindex','-1')}})</script>
 </head>
 <body>

--- a/index-ko.html
+++ b/index-ko.html
@@ -13,9 +13,9 @@
   <link rel="alternate" hreflang="es" href="https://gigaroute.ai/index-es.html">
   <link rel="alternate" hreflang="ja" href="https://gigaroute.ai/index-ja.html">
   <link rel="alternate" hreflang="x-default" href="https://gigaroute.ai/">
-  <link rel="stylesheet" href="site.css">
+  <link rel="stylesheet" href="site.css?v=20260904-3">
   <style>.consulting-panel:after{display:none!important}.consulting-panel+.consulting-panel{margin-top:28px}.actions .linux-download{pointer-events:none;cursor:not-allowed;opacity:.42;filter:grayscale(1)}</style>
-  <script src="contact.js" defer></script>
+  <script src="contact.js?v=20260904-3" defer></script>
   <script>window.addEventListener('DOMContentLoaded',()=>{const b=document.querySelector('.actions .linux-download');if(b){b.removeAttribute('href');b.removeAttribute('target');b.setAttribute('aria-disabled','true');b.setAttribute('tabindex','-1')}})</script>
 </head>
 <body>

--- a/index-zh.html
+++ b/index-zh.html
@@ -15,14 +15,14 @@
   <link rel="alternate" hreflang="ja" href="https://gigaroute.ai/index-ja.html">
   <link rel="alternate" hreflang="x-default" href="https://gigaroute.ai/">
   <link rel="icon" type="image/png" href="favicon.png">
-  <link rel="stylesheet" href="site.css">
+  <link rel="stylesheet" href="site.css?v=20260904-3">
   <style>
     html[lang="zh-CN"]{font-family:"Microsoft YaHei UI","Microsoft YaHei","PingFang SC","Hiragino Sans GB","Source Han Sans SC","Noto Sans CJK SC",Arial,sans-serif}
     html[lang="zh-CN"] body,html[lang="zh-CN"] button,html[lang="zh-CN"] input,html[lang="zh-CN"] select,html[lang="zh-CN"] textarea{font-family:inherit}
     .consulting-panel:after{display:none!important}.consulting-panel+.consulting-panel{margin-top:28px}
     .actions .linux-download{pointer-events:none;cursor:not-allowed;opacity:.42;filter:grayscale(1)}
   </style>
-  <script src="contact.js" defer></script>
+  <script src="contact.js?v=20260904-3" defer></script>
   <script>window.addEventListener('DOMContentLoaded',()=>{const b=document.querySelector('.actions .linux-download');if(b){b.removeAttribute('href');b.removeAttribute('target');b.setAttribute('aria-disabled','true');b.setAttribute('tabindex','-1')}})</script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
   <link rel="alternate" hreflang="es" href="https://gigaroute.ai/index-es.html">
   <link rel="alternate" hreflang="ja" href="https://gigaroute.ai/index-ja.html">
   <link rel="alternate" hreflang="x-default" href="https://gigaroute.ai/">
-  <link rel="stylesheet" href="site.css">
+  <link rel="stylesheet" href="site.css?v=20260904-3">
   <style>.consulting-panel:after{display:none!important}.consulting-panel+.consulting-panel{margin-top:28px}.actions .linux-download{pointer-events:none;cursor:not-allowed;opacity:.42;filter:grayscale(1)}</style>
-  <script src="contact.js" defer></script>
+  <script src="contact.js?v=20260904-3" defer></script>
   <script>window.addEventListener('DOMContentLoaded',()=>{const b=document.querySelector('.actions .linux-download');if(b){b.removeAttribute('href');b.removeAttribute('target');b.setAttribute('aria-disabled','true');b.setAttribute('tabindex','-1')}})</script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
직전 PR(#41, #42)에서 앵커 스크롤 여백 문제를 서버 소스 상으로는 확실히 고쳤고 GitHub Pages 배포도 성공했는데, 사용자가 배포 직후 재확인했을 때도 예전과 동일한 화면(과도한 빈 공간)이 계속 보인다는 리포트가 있었습니다.

원인은 `site.css`/`contact.js`가 파일명이 고정돼 있어 배포 후에도 브라우저(특히 iOS Safari)가 캐시된 이전 버전을 계속 사용하기 때문으로 보입니다. 파비콘은 이미 `favicon.png?v=20260818-2`처럼 버전 쿼리스트링으로 캐시를 무효화하고 있었는데, `site.css`/`contact.js`에는 이 처리가 없었습니다.

- 6개 언어 페이지(index, index-ko, index-en, index-zh, index-ja, index-es) 전부에서 `site.css`, `contact.js` 참조에 `?v=20260904-3` 버전 쿼리스트링을 추가
- 이후 이 두 파일을 수정할 때마다 버전 값을 올려주면 배포 즉시 새 버전이 강제로 로드됩니다

## Test plan
- [ ] 배포 후 모바일 브라우저에서 캐시를 지우지 않고도 최신 앵커 스크롤 여백 수정이 바로 반영되는지 확인
- [ ] 6개 언어 페이지 모두 `site.css`, `contact.js` 요청에 새 버전 쿼리스트링이 붙어 나가는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpRTYBHvFkaZBJvFyLFqJC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpRTYBHvFkaZBJvFyLFqJC)_